### PR TITLE
Remove implied username == Webauthn Id

### DIFF
--- a/_example/storage.go
+++ b/_example/storage.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/egregors/passkey"
 	"github.com/go-webauthn/webauthn/webauthn"
+
+	"github.com/mstarongithub/passkey"
 )
 
 type Storage struct {
@@ -51,6 +53,18 @@ func (s *Storage) SaveUser(user passkey.User) {
 	defer s.uMu.Unlock()
 
 	s.users[user.WebAuthnName()] = user
+}
+
+func (s *Storage) GetUserByWebAuthnId(id []byte) passkey.User {
+	s.uMu.Lock()
+	defer s.uMu.Unlock()
+
+	// Storage implementation assumes that username == webauthn Id
+	if user, ok := s.users[string(id)]; ok {
+		return user
+	} else {
+		return nil
+	}
 }
 
 // -- Session storage methods --

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mstarongithub/passkey
+module github.com/egregors/passkey
 
 go 1.22
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/egregors/passkey
+module github.com/mstarongithub/passkey
 
 go 1.22
 

--- a/handlers.go
+++ b/handlers.go
@@ -37,7 +37,11 @@ func (p *Passkey) beginRegistration(w http.ResponseWriter, r *http.Request) {
 	t, err := p.sessionStore.GenSessionID()
 	if err != nil {
 		p.l.Errorf("can't generate session id: %s", err.Error())
-		JSONResponse(w, fmt.Sprintf("can't generate session id: %s", err.Error()), http.StatusInternalServerError)
+		JSONResponse(
+			w,
+			fmt.Sprintf("can't generate session id: %s", err.Error()),
+			http.StatusInternalServerError,
+		)
 
 		return
 	}
@@ -70,7 +74,7 @@ func (p *Passkey) finishRegistration(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO: username != user id? need to check
-	user := p.userStore.GetOrCreateUser(string(session.UserID)) // Get the user
+	user := p.userStore.GetOrCreateUserByWebAuthnId(session.UserID) // Get the user
 
 	credential, err := p.webAuthn.FinishRegistration(user, *session, r)
 	if err != nil {
@@ -120,7 +124,11 @@ func (p *Passkey) beginLogin(w http.ResponseWriter, r *http.Request) {
 	t, err := p.sessionStore.GenSessionID()
 	if err != nil {
 		p.l.Errorf("can't generate session id: %s", err.Error())
-		JSONResponse(w, fmt.Sprintf("can't generate session id: %s", err.Error()), http.StatusInternalServerError)
+		JSONResponse(
+			w,
+			fmt.Sprintf("can't generate session id: %s", err.Error()),
+			http.StatusInternalServerError,
+		)
 
 		return
 	}
@@ -146,7 +154,7 @@ func (p *Passkey) finishLogin(w http.ResponseWriter, r *http.Request) {
 	session, _ := p.sessionStore.GetSession(sid.Value) // FIXME: cover invalid session
 
 	// TODO: username != user id? need to check
-	user := p.userStore.GetOrCreateUser(string(session.UserID)) // Get the user
+	user := p.userStore.GetOrCreateUserByWebAuthnId(session.UserID) // Get the user
 
 	credential, err := p.webAuthn.FinishLogin(user, *session, r)
 	if err != nil {
@@ -173,7 +181,11 @@ func (p *Passkey) finishLogin(w http.ResponseWriter, r *http.Request) {
 	t, err := p.sessionStore.GenSessionID()
 	if err != nil {
 		p.l.Errorf("can't generate session id: %s", err.Error())
-		JSONResponse(w, fmt.Sprintf("can't generate session id: %s", err.Error()), http.StatusInternalServerError)
+		JSONResponse(
+			w,
+			fmt.Sprintf("can't generate session id: %s", err.Error()),
+			http.StatusInternalServerError,
+		)
 
 		return
 	}

--- a/ifaces.go
+++ b/ifaces.go
@@ -16,7 +16,7 @@ type User interface {
 
 type UserStore interface {
 	GetOrCreateUser(userID string) User
-	GetOrCreateUserByWebAuthnId(id []byte) User
+	GetUserByWebAuthnId(id []byte) User
 	SaveUser(User)
 }
 

--- a/ifaces.go
+++ b/ifaces.go
@@ -16,6 +16,7 @@ type User interface {
 
 type UserStore interface {
 	GetOrCreateUser(userID string) User
+	GetOrCreateUserByWebAuthnId(id []byte) User
 	SaveUser(User)
 }
 


### PR DESCRIPTION
Fixes #27 by adding a new function to the `UserStore` interface for receiving a user via a provided WebAuthn Id instead of a username. Additionally, the new function is now used in the `finishRegistration` and `finishLogin` handlers instead of first assuming the WebAuthn Id matches the username and then using that as a username.